### PR TITLE
Prepare 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-contracts",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Design by Contract for JavaScript via a Babel plugin.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ export default function ({types: t, template, options}: PluginParams): Plugin {
         message = t.stringLiteral(`Function ${name}precondition failed: ${generate(condition.node).code}`);
       }
       path.replaceWith(guard({
-        condition,
+        condition: staticCheck(condition),
         message
       }));
       return;
@@ -102,7 +102,7 @@ export default function ({types: t, template, options}: PluginParams): Plugin {
           message = t.stringLiteral(`Function ${name}precondition failed: ${generate(condition.node).code}`);
         }
         statement.replaceWith(guard({
-          condition,
+          condition: staticCheck(condition),
           message
         }));
       }
@@ -135,7 +135,7 @@ export default function ({types: t, template, options}: PluginParams): Plugin {
         message = t.stringLiteral(`Function ${name}postcondition failed: ${generate(condition.node).code}`);
       }
       conditions.push(guard({
-        condition,
+        condition: staticCheck(condition),
         message
       }));
     }
@@ -167,7 +167,7 @@ export default function ({types: t, template, options}: PluginParams): Plugin {
             message = t.stringLiteral(`Function ${name}postcondition failed: ${generate(condition.node).code}`);
           }
           statement.replaceWith(guard({
-            condition,
+            condition: staticCheck(condition),
             message
           }));
         }
@@ -206,7 +206,7 @@ export default function ({types: t, template, options}: PluginParams): Plugin {
         message = t.stringLiteral(`Assertion failed: ${generate(condition.node).code}`);
       }
       path.replaceWith(guard({
-        condition,
+        condition: staticCheck(condition),
         message
       }));
       return;
@@ -231,7 +231,7 @@ export default function ({types: t, template, options}: PluginParams): Plugin {
           message = t.stringLiteral(`Assertion failed: ${generate(condition.node).code}`);
         }
         statement.replaceWith(guard({
-          condition,
+          condition: staticCheck(condition),
           message
         }));
       }
@@ -263,7 +263,7 @@ export default function ({types: t, template, options}: PluginParams): Plugin {
         message = t.stringLiteral(`Function ${name}invariant failed: ${generate(condition.node).code}`);
       }
       conditions.push(guard({
-        condition,
+        condition: staticCheck(condition),
         message
       }));
     }
@@ -284,7 +284,7 @@ export default function ({types: t, template, options}: PluginParams): Plugin {
             message = t.stringLiteral(`Function ${name}invariant failed: ${generate(condition.node).code}`);
           }
           statement.replaceWith(guard({
-            condition,
+            condition: staticCheck(condition),
             message
           }));
         }
@@ -309,6 +309,15 @@ export default function ({types: t, template, options}: PluginParams): Plugin {
       const node: Node = fn(...args);
       return getExpression(node);
     };
+  }
+
+  function staticCheck (expression: NodePath): NodePath {
+    const {confident, value} = expression.evaluate();
+    if (confident && !value) {
+      throw expression.buildCodeFrameError(`Contract always fails.`);
+    }
+
+    return expression;
   }
 
   return {

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ export default function ({types: t, template, options}: PluginParams): Plugin {
   `);
 
   const guardFn: (ids: {[key: string]: Node}) => Node = template(`
-    function id (it) {
+    const id = (it) => {
       conditions;
       return it;
     }
@@ -177,12 +177,13 @@ export default function ({types: t, template, options}: PluginParams): Plugin {
 
     const id = path.scope.generateUidIdentifier(`${fn.node.id ? fn.node.id.name : 'check'}Postcondition`);
 
-    path.replaceWith(guardFn({
+    fn.get('body').get('body')[0].insertBefore(guardFn({
       id,
       conditions,
       it: returnId
     }));
 
+    path.remove();
     return id;
   }
 
@@ -292,13 +293,12 @@ export default function ({types: t, template, options}: PluginParams): Plugin {
     }
 
     const id = path.scope.generateUidIdentifier(`${fn.node.id ? fn.node.id.name : 'check'}Invariant`);
-
-    path.replaceWith(guardFn({
+    path.parentPath.get('body')[0].insertBefore(guardFn({
       id,
       conditions,
       it: returnId
     }));
-
+    path.remove();
     return id;
   }
 
@@ -354,7 +354,7 @@ export default function ({types: t, template, options}: PluginParams): Plugin {
               parent = path.findParent(t.isBlockStatement);
               children = parent.get('body');
               const first: NodePath = children[0];
-              first.insertBefore(t.expressionStatement(t.callExpression(id, [])))
+              first.insertAfter(t.expressionStatement(t.callExpression(id, [])))
             }
             parent.traverse({
               Function (path: NodePath): void {

--- a/test/fixtures/bad-assert-no-function.js
+++ b/test/fixtures/bad-assert-no-function.js
@@ -1,5 +1,9 @@
-assert: false;
+assert: fail();
 
 export default function demo (input) {
   assert: input.length > 0;
+}
+
+function fail () {
+  return false;
 }

--- a/test/fixtures/bad-precondition-always-false.js
+++ b/test/fixtures/bad-precondition-always-false.js
@@ -1,0 +1,6 @@
+export default function demo (input) {
+  pre: {
+    false;
+  }
+  return input.length;
+}

--- a/test/fixtures/class.js
+++ b/test/fixtures/class.js
@@ -1,0 +1,22 @@
+class Thing {
+  constructor (input) {
+    this.input = input;
+  }
+
+  set (input) {
+    pre: {
+      typeof this.input === 'string';
+    }
+    post: {
+      this.input !== old(this.input);
+    }
+
+    this.input = input;
+  }
+}
+
+export default function demo (first, second) {
+  const thing = new Thing(first);
+  thing.set(second);
+  return thing;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,7 @@ else {
 }
 
 describe('Typecheck', function () {
+  ok('class', 'first', 'second');
   ok('old-value', 5, 5);
   failWith(`Function "add5" postcondition failed: input === old(input) + 5`, 'old-value', 5, 10);
   ok('old-value-object', {price: 5}, 5);

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,7 @@ else {
 }
 
 describe('Typecheck', function () {
+  failStatic('bad-precondition-always-false', 'foobar');
   ok('class', 'first', 'second');
   ok('old-value', 5, 5);
   failWith(`Function "add5" postcondition failed: input === old(input) + 5`, 'old-value', 5, 10);
@@ -33,7 +34,7 @@ describe('Typecheck', function () {
   ok('assert-with-message', 'hello');
   failWith(`input cannot be empty`, 'assert-with-message', '');
   ok('assert-no-function', 'hello');
-  failWith(`Assertion failed: false`, 'bad-assert-no-function', 'hello');
+  failWith(`Assertion failed: fail()`, 'bad-assert-no-function', 'hello');
   ok('example-2', 1, 2);
   ok('example-2', 1);
   ok('example-2', 0, 2);


### PR DESCRIPTION
Fixes a bug where `this` would lose context within checks in methods. Also adds (limited) static verification of contracts, so if you write something like `pre: false` you'll get a `SyntaxError` at compile time.
