### PR TITLE
Fixed .babelrc example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,15 @@ npm install --save-dev babel-plugin-contracts
 Then, in your babel configuration (usually in your `.babelrc` file), add `"contracts"` to your list of plugins:
 ```json
 {
-  "plugins": ["contracts", {
-    "env": {
-      "production": {
-        "strip": true
+  "plugins": [
+    ["contracts", {
+      "env": {
+        "production": {
+          "strip": true
+        }
       }
-    }
-  }]
+    }]
+  ]
 }
 ```
 


### PR DESCRIPTION
I was getting errors using the example `.babelrc` configuration: `plugins` should be an array of arrays.
