### PR TITLE
Upgrade to Babel 7

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,8 @@
 {
   "presets": [
-    "stage-0",
-    "es2015"
+    "@babel/preset-env"
   ],
   "plugins": [
-    "typecheck"
+    "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,4 @@ sudo: false
 language: node_js
 
 node_js:
-  - "0.12"
-  - "iojs"
-  - "4.2.1"
+  - "6.17.1"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Design by Contract for JavaScript via a Babel plugin.",
   "main": "lib/index.js",
   "scripts": {
-    "build": "babel --plugins syntax-flow,transform-flow-strip-types -d ./lib ./src",
-    "build-typed": "npm run build && babel --plugins ./lib,syntax-flow,transform-flow-strip-types -d ./lib-checked ./src",
+    "build": "babel --plugins @babel/plugin-syntax-flow,@babel/plugin-transform-flow-strip-types -d ./lib ./src",
+    "build-typed": "npm run build && babel --plugins ./lib,@babel/plugin-syntax-flow,@babel/plugin-transform-flow-strip-types -d ./lib-checked ./src",
     "prepublish": "npm run build",
     "pretest": "npm run build",
     "test": "mocha ./test/index.js",
@@ -33,22 +33,18 @@
   },
   "homepage": "https://github.com/codemix/babel-plugin-contracts",
   "dependencies": {
-    "babel-generator": "^6.1.2"
+    "@babel/generator": "^7.4.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.1.0",
-    "babel-core": "^6.1.0",
-    "babel-plugin-syntax-class-properties": "^6.1.18",
-    "babel-plugin-syntax-flow": "^6.0.14",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.1.3",
-    "babel-plugin-transform-flow-strip-types": "^6.0.14",
-    "babel-plugin-typecheck": "^3.9.0",
-    "babel-polyfill": "^6.0.16",
-    "babel-preset-es2015": "^6.1.0",
-    "babel-preset-react": "^6.1.0",
-    "babel-preset-stage-0": "^6.1.18",
-    "babel-preset-stage-1": "^6.1.0",
-    "mocha": "~2.2.4",
-    "should": "^6.0.1"
+    "@babel/cli": "^7.4.3",
+    "@babel/core": "^7.4.3",
+    "@babel/plugin-proposal-class-properties": "^7.4.0",
+    "@babel/plugin-syntax-flow": "^7.2.0",
+    "@babel/plugin-transform-flow-strip-types": "^7.4.0",
+    "@babel/polyfill": "^7.4.3",
+    "@babel/preset-env": "^7.4.3",
+    "@babel/register": "^7.4.0",
+    "mocha": "~6.1.2",
+    "should": "^13.2.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import generate from "babel-generator";
+import generate from "@babel/generator";
 
 type Plugin = {
   visitor: Visitors
@@ -55,15 +55,15 @@ export default function ({types: t, template, options}: PluginParams): Plugin {
   let NAMES = Object.assign({}, defaultNames);
 
   const guard: (ids: {[key: string]: Node}) => Node = template(`
-    if (!condition) {
-      throw new Error(message);
+    if (!%%condition%%) {
+      throw new Error(%%message%%);
     }
   `);
 
   const guardFn: (ids: {[key: string]: Node}) => Node = template(`
-    const id = (it) => {
-      conditions;
-      return it;
+    const %%id%% = (%%it%%) => {
+      %%conditions%%;
+      return %%it%%;
     }
   `);
 
@@ -320,7 +320,7 @@ export default function ({types: t, template, options}: PluginParams): Plugin {
       throw expression.buildCodeFrameError(`Contract always fails.`);
     }
 
-    return expression;
+    return expression.node;
   }
 
   return {

--- a/test-polyfill.js
+++ b/test-polyfill.js
@@ -1,7 +1,8 @@
-require("babel-core/register")({
-  "presets": ["stage-1", "es2015"],
+require("@babel/register")({
+  "presets": ["@babel/preset-env"],
   "plugins": [
-    //"syntax-flow",
-    "transform-flow-strip-types"
+    //"@babel/plugin-syntax-flow",
+    "@babel/plugin-transform-flow-strip-types",
+    "@babel/plugin-proposal-class-properties"
   ]
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import {parse, transform, traverse} from 'babel-core';
+import {transform} from '@babel/core';
 
 if (process.env.NODE_WATCH) {
   var contracts = require('../src').default;
@@ -105,8 +105,7 @@ function loadInternal (basename) {
   const transformed = transform(source, {
     filename: filename,
     presets: [
-      "es2015",
-      "stage-0",
+      "@babel/preset-env"
     ],
     plugins: [
       [contracts, {
@@ -114,8 +113,8 @@ function loadInternal (basename) {
           return: 'retVal',
         }
       }],
-      'transform-flow-strip-types',
-      'syntax-class-properties'
+      "@babel/plugin-transform-flow-strip-types",
+      "@babel/plugin-proposal-class-properties"
     ]
   });
   const context = {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
 --reporter=spec
 --require should
---require babel-polyfill
+--require @babel/polyfill
 --require ./test-polyfill.js


### PR DESCRIPTION
This PR upgrades all the Babel dependencies to the corresponding Babel 7 packages in the `@babel` scope, and changes `src/index.js` ever so slightly to comply with the breaking changes.

Closes https://github.com/codemix/babel-plugin-contracts/issues/9